### PR TITLE
Fixed a command search error inside the text

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 		}
 
 		for _, command := range commands {
-			if strings.Contains(update.Message.Text, command) {
+			if update.Message.Text == command || strings.Contains(update.Message.Text, " "+command+" ") {
 				switch command {
 				case "/help", "/хелп":
 					message = `БОТ РАБОТАЕТ ТОЛЬКО У АДМИНОВ.


### PR DESCRIPTION
The bot was triggered when there was a link in the message containing a command, for example (/go): `https://www.ribice.ba/golang-memory-savings/`